### PR TITLE
fix(package.json): change name to openbroject

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openbroject4",
+  "name": "openbroject",
   "version": "0.1.0",
   "private": true,
   "scripts": {


### PR DESCRIPTION
Problem: Typo in package.json name.
Solution: Renamed "openbroject4" to "openbroject".